### PR TITLE
Use print_ascii to make it work in powershell

### DIFF
--- a/extract_otp_secret_keys.py
+++ b/extract_otp_secret_keys.py
@@ -78,7 +78,7 @@ def save_qr(data, name):
 def print_qr(data):
     qr = QRCode()
     qr.add_data(data)
-    qr.print_tty()
+    qr.print_ascii()
 
 i = j = 0
 for line in (line.strip() for line in fileinput.input(args.infile)):


### PR DESCRIPTION
qr.print_tty() doesn't work on windows, but qr.print_ascii() does.

May look a bit less formatted, but can still be scanned.