### PR TITLE
Test mutually exclusive arguments verbose and quiet

### DIFF
--- a/extract_otp_secret_keys.py
+++ b/extract_otp_secret_keys.py
@@ -79,7 +79,7 @@ def parse_args(sys_args):
     arg_parser.add_argument('--quiet', '-q', help='no stdout output', action='store_true')
     args = arg_parser.parse_args(sys_args)
     if args.verbose and args.quiet:
-        print("The arguments --verbose and --quite are mutual exclusive.")
+        print("The arguments --verbose and --quiet are mutually exclusive.")
         sys.exit(1)
     return args
 

--- a/test_extract_otp_secret_keys_pytest.py
+++ b/test_extract_otp_secret_keys_pytest.py
@@ -209,6 +209,16 @@ def test_extract_help(capsys):
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 0
 
+def test_verbose_and_quiet(capsys):
+    with raises(SystemExit) as pytest_wrapped_e:
+        # Act
+        extract_otp_secret_keys.main(['-v', '-q', 'example_export.txt'])
+
+    # Assert
+    captured = capsys.readouterr()
+
+    assert len(captured.out) > 0
+    assert 'The arguments --verbose and --quiet are mutually exclusive.' in captured.out
 
 def cleanup():
     remove_file('test_example_output.csv')


### PR DESCRIPTION
- Fixed typos and grammar in error message
- Added test case for mutually exclusive arguments verbose and quiet